### PR TITLE
fix: add toggle to bypass calling .source() method on compiled resour…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,5 @@ The third option `configFunction` allows you to modify the webpack config.
 
 ## Known Bugs
 
-- When the `eleventyConfig.addCachedGlobalData` property is truthy, the plugin will attempt to extract files and use the `.source()` method, which does not exist on the `assets` constructor: `SizeOnlySource` (ref #1)
+- ~~When the `eleventyConfig.addCachedGlobalData` property is truthy, the plugin will attempt to extract files and use the `.source()` method, which does not exist on the `assets` constructor: `SizeOnlySource` (ref [#1](https://github.com/geoffdavis92/eleventy-plugin-webpack/issues/1))~~
+  - Addressed by [PR #8](https://github.com/geoffdavis92/eleventy-plugin-webpack/pull/8)

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const mfs = new MemoryFileSystem();
 const fs = require("fs-extra");
 const getDefaultConfig = require("./default-config");
 const { addCachedGlobalData } = require("./utils");
+const bypassSourceMethod = true;
 
 const extractFiles = (
   compilerResult,
@@ -12,7 +13,7 @@ const extractFiles = (
   const { addCachedGlobalData } = configObj;
 
   return Object.keys(compilerResult.assets).reduce((acc, key) => {
-    if (addCachedGlobalData) {
+    if (addCachedGlobalData && !bypassSourceMethod) {
       acc[key] = compilerResult.assets[key].source();
     } else {
       acc[key] = compilerResult.assets[key];


### PR DESCRIPTION
This PR updates the `extractFiles` function by adding a static toggle to bypass the option to call assets' `.source()` method. This prevents an error and non-zero exit code from breaking Eleventy builds.

When testing with my own Eleventy project– both locally and in production– there does not seem to be any adverse side effects to bypassing the `.source()` method.

Related to #1 